### PR TITLE
Add @jill64/svelte-html package and tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,2 @@
+/dist
+*.config.*

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,0 +1,24 @@
+extends:
+  - eslint:recommended
+  - plugin:@typescript-eslint/recommended
+  - plugin:svelte/recommended
+  - prettier
+parserOptions:
+  ecmaVersion: 2020
+  sourceType: module
+  project: ./tsconfig.json
+  extraFileExtensions:
+    - .svelte
+plugins:
+  - '@typescript-eslint'
+  - deprecation
+rules:
+  deprecation/deprecation: error
+env:
+  browser: true
+overrides:
+  - files:
+      - '*.svelte'
+    parser: svelte-eslint-parser
+    parserOptions:
+      parser: '@typescript-eslint/parser'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,9 @@
+name: CI
+
+on: push
+
+jobs:
+  test:
+    uses: jill64/.github/.github/workflows/run-vitest.yml@main
+  test-e2e:
+    uses: jill64/.github/.github/workflows/run-playwright.yml@main

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,12 @@
+.DS_Store
+node_modules
+/build
+/dist
+.svelte-kit
+.env
+.env.*
+!.env.example
+vite.config.js.timestamp-*
+vite.config.ts.timestamp-*
+pnpm-lock.yaml
+package-lock.json

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,5 @@
+{
+  "semi": false,
+  "singleQuote": true,
+  "trailingComma": "none"
+}

--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# svelte-html
-🏷️ Reactive attributes assignment for root html element
+<!----- BEGIN GHOST DOCS HEADER ----->
+<!----- END GHOST DOCS HEADER ----->

--- a/README.md
+++ b/README.md
@@ -6,6 +6,4 @@
 
 🏷️ Reactive attributes assignment for root html element
 
-
-
 <!----- END GHOST DOCS HEADER ----->

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 <!----- BEGIN GHOST DOCS HEADER ----->
+
+# svelte-html
+
+[![ci.yml](https://github.com/jill64/svelte-html/actions/workflows/ci.yml/badge.svg)](https://github.com/jill64/svelte-html/actions/workflows/ci.yml)
+
+🏷️ Reactive attributes assignment for root html element
+
+
+
 <!----- END GHOST DOCS HEADER ----->

--- a/package.json
+++ b/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@jill64/svelte-html",
+  "description": "",
+  "main": "dist/index.js",
+  "type": "module",
+  "license": "MIT",
+  "author": "jill64 <intents.turrets0h@icloud.com> (https://github.com/jill64)",
+  "bugs": "https://github.com/jill64/svelte-html/issues",
+  "homepage": "https://github.com/jill64/svelte-html#readme",
+  "files": [
+    "dist",
+    "!**/*.test.*",
+    "!**/*.spec.*"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "svelte": "./dist/index.js",
+      "default": "./dist/index.js"
+    }
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/jill64/svelte-html.git"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "keywords": [
+    "svelte",
+    "html",
+    "tag",
+    "attribute",
+    "reactive"
+  ],
+  "scripts": {
+    "dev": "vite dev",
+    "build": "vite build && npm run package",
+    "preview": "npm run build && vite preview",
+    "prepack": "npm run build",
+    "package": "svelte-kit sync && npx @sveltejs/package && npx publint",
+    "check": "svelte-kit sync && npx svelte-check",
+    "lint": "npx eslint . && npm run check",
+    "format": "npx prettier --write . --plugin prettier-plugin-svelte .",
+    "test": "vitest",
+    "test:e2e": "playwright test"
+  },
+  "peerDependencies": {
+    "svelte": "^4.0.0"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.39.0",
+    "@sveltejs/adapter-auto": "2.1.0",
+    "@sveltejs/kit": "1.27.2",
+    "@typescript-eslint/eslint-plugin": "6.9.1",
+    "@typescript-eslint/parser": "6.9.1",
+    "eslint-config-prettier": "9.0.0",
+    "eslint-plugin-deprecation": "2.0.0",
+    "eslint-plugin-svelte": "2.34.0",
+    "prettier-plugin-svelte": "3.0.3",
+    "svelte": "4.2.2",
+    "typescript": "5.2.2",
+    "vite": "4.5.0",
+    "vitest": "0.34.6"
+  }
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,34 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  webServer: {
+    command: 'npm run preview',
+    port: 4173
+  },
+  testDir: 'tests',
+  fullyParallel: true,
+  retries: process.env.CI ? 2 : 0,
+  workers: '100%',
+  projects: [
+    {
+      name: 'chromium',
+      use: devices['Desktop Chrome']
+    },
+    {
+      name: 'firefox',
+      use: devices['Desktop Firefox']
+    },
+    {
+      name: 'webkit',
+      use: devices['Desktop Safari']
+    },
+    {
+      name: 'Mobile Chrome',
+      use: devices['Pixel 5']
+    },
+    {
+      name: 'Mobile Safari',
+      use: devices['iPhone 12']
+    }
+  ]
+})

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:best-practices", ":pinDependencies"]
+}

--- a/rsac.yml
+++ b/rsac.yml
@@ -1,0 +1,6 @@
+branch-protection:
+  main:
+    required_status_checks:
+      contexts:
+        - test / run-vitest
+        - test-e2e / run-playwright

--- a/src/app.html
+++ b/src/app.html
@@ -1,0 +1,11 @@
+<!doctype html>
+<html lang="unknown">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    %sveltekit.head%
+  </head>
+  <body data-sveltekit-preload-data="hover" data-sveltekit-preload-code="eager">
+    <div>%sveltekit.body%</div>
+  </body>
+</html>

--- a/src/hooks.server.ts
+++ b/src/hooks.server.ts
@@ -1,0 +1,6 @@
+import { bind } from '$lib'
+
+export const handle = bind({
+  lang: 'zh',
+  prefix: 'https://example.com'
+})

--- a/src/lib/SvelteHtml.svelte
+++ b/src/lib/SvelteHtml.svelte
@@ -1,0 +1,13 @@
+<script lang="ts">
+  import { browser } from '$app/environment'
+
+  $: if (browser) {
+    const html = document.getElementsByTagName('html')[0]
+
+    Object.entries($$props).forEach(([key, value]) => {
+      if (html.getAttribute(key) !== value) {
+        value ? html.setAttribute(key, value) : html.removeAttribute(key)
+      }
+    })
+  }
+</script>

--- a/src/lib/bind.ts
+++ b/src/lib/bind.ts
@@ -1,0 +1,8 @@
+import type { Handle } from '@sveltejs/kit'
+import { transform } from './utils/transform'
+
+export const bind = (attributes: Record<string, string>) =>
+  (({ event, resolve }) =>
+    resolve(event, {
+      transformPageChunk: ({ html }) => transform(html, attributes)
+    })) satisfies Handle

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,0 +1,2 @@
+export { default as SvelteHTML } from './SvelteHtml.svelte'
+export { bind } from './bind'

--- a/src/lib/utils/parseAttributes.test.ts
+++ b/src/lib/utils/parseAttributes.test.ts
@@ -1,0 +1,13 @@
+import { expect, test } from 'vitest'
+import { parseAttributes } from './parseAttributes'
+
+test('parseAttributes', () => {
+  expect(parseAttributes('<html>')).toEqual({})
+  expect(parseAttributes('<html lang="en">')).toEqual({ lang: 'en' })
+  expect(
+    parseAttributes(`<html lang="ja" prefix='og: http://ogp.me/ns#'>`)
+  ).toEqual({
+    lang: 'ja',
+    prefix: 'og: http://ogp.me/ns#'
+  })
+})

--- a/src/lib/utils/parseAttributes.ts
+++ b/src/lib/utils/parseAttributes.ts
@@ -1,0 +1,15 @@
+export const parseAttributes = (raw: string): Record<string, string> => {
+  const attributes = raw.match(/([a-zA-Z-]+)=["'](.*?)["']/g)
+
+  if (!attributes) {
+    return {}
+  }
+
+  return attributes.reduce((acc, cur) => {
+    const [key, value] = cur.split('=')
+    return {
+      ...acc,
+      [key]: value.replace(/["']/g, '')
+    }
+  }, {})
+}

--- a/src/lib/utils/transform.test.ts
+++ b/src/lib/utils/transform.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from 'vitest'
+import { transform } from './transform'
+
+test('transform', () => {
+  expect(transform('<html>', {})).toBe('<html>')
+
+  expect(transform('<html>', { lang: 'en' })).toBe('<html lang="en">')
+
+  expect(transform('<a>', { lang: 'en' })).toBe('<a>')
+
+  expect(transform('<html lang="test">', { lang: 'en' })).toBe(
+    '<html lang="en">'
+  )
+
+  expect(transform('<html>', { prefix: 'og: http://ogp.me/ns#' })).toBe(
+    '<html prefix="og: http://ogp.me/ns#">'
+  )
+
+  expect(
+    transform("<html lang='test'>", {
+      lang: 'en',
+      prefix: 'og: http://ogp.me/ns#'
+    })
+  ).toBe('<html lang="en" prefix="og: http://ogp.me/ns#">')
+
+  expect(
+    transform('<html>', { lang: 'en', prefix: 'og: http://ogp.me/ns#' })
+  ).toBe('<html lang="en" prefix="og: http://ogp.me/ns#">')
+})

--- a/src/lib/utils/transform.ts
+++ b/src/lib/utils/transform.ts
@@ -1,0 +1,18 @@
+import { parseAttributes } from './parseAttributes'
+
+export const transform = (
+  html: string,
+  attributes: Record<string, string>
+): string =>
+  html.replace(/<html(.*?)>/, (_, p1) => {
+    const attr = Object.entries({
+      ...parseAttributes(p1 ? p1 : ''),
+      ...attributes
+    })
+      .map(([key, value]) => `${key}="${value}"`)
+      .join(' ')
+
+    const str = attr ? ` ${attr}` : ''
+
+    return `<html${str}>`
+  })

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -1,0 +1,87 @@
+<script lang="ts">
+  import SvelteHtml from '$lib/SvelteHtml.svelte'
+
+  let attributes = [
+    {
+      key: 'lang',
+      value: 'en'
+    },
+    {
+      key: 'prefix',
+      value: 'og: http://ogp.me/ns#'
+    }
+  ]
+</script>
+
+<SvelteHtml
+  {...Object.fromEntries(attributes.map(({ key, value }) => [key, value]))}
+/>
+<h1>@jill64/svelte-html</h1>
+<p>Open the Dev Tool and check that the html tag attributes have changed.</p>
+<main>
+  {#each attributes as { key, value }, index}
+    <button
+      style:font-size="large"
+      on:click={() => {
+        attributes = attributes
+          .slice(0, index)
+          .concat(attributes.slice(index + 1))
+      }}
+    >
+      X
+    </button>
+    <input bind:value={key} />
+    <span>=</span>
+    <input bind:value title={key} />
+  {/each}
+  <button
+    style:font-size="xx-large"
+    style:display="flex"
+    style:justify-self="center"
+    on:click={() => {
+      attributes = [...attributes, { key: '', value: '' }]
+    }}
+  >
+    ＋
+  </button>
+</main>
+
+<style>
+  :global(body) {
+    font-family: sans-serif;
+  }
+  @media (prefers-color-scheme: dark) {
+    :global(body) {
+      background-color: #222;
+      color: #eee;
+    }
+  }
+  main {
+    display: grid;
+    grid-template-columns: auto auto auto auto;
+    align-items: center;
+    justify-content: center;
+    font-size: x-large;
+  }
+  input {
+    color: inherit;
+    background-color: inherit;
+    border: 1px solid;
+    border-radius: 0.25rem;
+    padding: 0.5rem;
+    margin: 0.5rem;
+    font-size: inherit;
+  }
+  button {
+    color: inherit;
+    background-color: inherit;
+    border: 1px solid;
+    border-radius: 0.5rem;
+    padding: 0.5rem;
+    margin: 0.5rem;
+    cursor: pointer;
+    user-select: none;
+    -moz-user-select: none;
+    -webkit-user-select: none;
+  }
+</style>

--- a/svelte.config.js
+++ b/svelte.config.js
@@ -1,0 +1,12 @@
+import adapter from '@sveltejs/adapter-auto'
+import { vitePreprocess } from '@sveltejs/kit/vite'
+
+/** @type {import('@sveltejs/kit').Config} */
+const config = {
+  preprocess: vitePreprocess(),
+  kit: {
+    adapter: adapter()
+  }
+}
+
+export default config

--- a/tests/smoke.spec.ts
+++ b/tests/smoke.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@playwright/test'
+
+test('smoke', async ({ page }) => {
+  await page.goto('/')
+
+  await expect(
+    page.getByRole('heading', { name: '@jill64/svelte-html' })
+  ).toBeVisible()
+
+  const lang2 = await page.locator('html').getAttribute('lang')
+  expect(lang2).toBe('en')
+
+  const prefix2 = await page.locator('html').getAttribute('prefix')
+  expect(prefix2).toBe('og: http://ogp.me/ns#')
+
+  await page.getByRole('textbox', { name: 'lang' }).fill('ja')
+
+  const lang3 = await page.locator('html').getAttribute('lang')
+  expect(lang3).toBe('ja')
+})

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  }
+}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,0 +1,9 @@
+import { sveltekit } from '@sveltejs/kit/vite'
+import { defineConfig } from 'vitest/config'
+
+export default defineConfig({
+  plugins: [sveltekit()],
+  test: {
+    include: ['**/*.test.ts']
+  }
+})


### PR DESCRIPTION
This pull request adds the @jill64/svelte-html package, which provides reactive attributes assignment for the root HTML element in Svelte applications. It also includes tests for the package.

Commits included in this pull request:

- setup

- Add tests and implementation for parseAttributes and transform functions

- Add SvelteHtml component and bind utility function

- Add new HTML file, server hook, and Svelte page component.

- Add smoke test for @jill64/svelte-html package

- chore: synchronize README.md

- chore: format

No issue number reference is included in this pull request.